### PR TITLE
Adds min_value parameter to zyncoder

### DIFF
--- a/zyncoder.h
+++ b/zyncoder.h
@@ -92,6 +92,7 @@ struct zyncoder_st {
 	unsigned int osc_port;
 	lo_address osc_lo_addr;
 	char osc_path[512];
+	unsigned int min_value;
 	unsigned int max_value;
 	unsigned int step;
 	volatile unsigned int subvalue;
@@ -104,7 +105,8 @@ struct zyncoder_st zyncoders[MAX_NUM_ZYNCODERS];
 
 void midi_event_zyncoders(uint8_t midi_chan, uint8_t midi_ctrl, uint8_t val);
 
-struct zyncoder_st *setup_zyncoder(uint8_t i, uint8_t pin_a, uint8_t pin_b, uint8_t midi_chan, uint8_t midi_ctrl, char *osc_path, unsigned int value, unsigned int max_value, unsigned int step); 
+struct zyncoder_st *setup_zyncoder(uint8_t i, uint8_t pin_a, uint8_t pin_b, uint8_t midi_chan, uint8_t midi_ctrl, char *osc_path, unsigned int value, unsigned int max_value, unsigned int step);
+struct zyncoder_st *setup_zyncoder_with_min(uint8_t i, uint8_t pin_a, uint8_t pin_b, uint8_t midi_chan, uint8_t midi_ctrl, char *osc_path, unsigned int value, unsigned int min_value, unsigned int max_value, unsigned int step);
 unsigned int get_value_zyncoder(uint8_t i);
 void set_value_zyncoder(uint8_t i, unsigned int v, int send);
 

--- a/zyncoder_i2c.h
+++ b/zyncoder_i2c.h
@@ -78,6 +78,7 @@ struct zyncoder_st {
 	unsigned int osc_port;
 	lo_address osc_lo_addr;
 	char osc_path[512];
+	unsigned int min_value;
 	unsigned int max_value;
 	unsigned int step;
 	volatile unsigned int value;
@@ -88,6 +89,7 @@ struct zyncoder_st zyncoders[MAX_NUM_ZYNCODERS];
 void midi_event_zyncoders(uint8_t midi_chan, uint8_t midi_ctrl, uint8_t val);
 
 struct zyncoder_st *setup_zyncoder(uint8_t i, uint8_t pin_a, uint8_t pin_b, uint8_t midi_chan, uint8_t midi_ctrl, char *osc_path, unsigned int value, unsigned int max_value, unsigned int step);
+struct zyncoder_st *setup_zyncoder_with_min(uint8_t i, uint8_t pin_a, uint8_t pin_b, uint8_t midi_chan, uint8_t midi_ctrl, char *osc_path, unsigned int value, unsigned int min_value, unsigned int max_value, unsigned int step);
 unsigned int get_value_zyncoder(uint8_t i);
 void set_value_zyncoder(uint8_t i, unsigned int v, int send);
 


### PR DESCRIPTION
This change adds an extra parameter to zyncoder: `min_value`. An extra function is added to allow this value to be configured during setup with old behaviour remaining the same, i.e. backward compatible. Range validation checks are performed to ensure max > min and min <= value <= max.

This change is required for stepseq latest commit and should fix issues where the encoder value falls below the applications expected minimum value which exhibits behaviour of encoder appearing to do nothing / hysteresis.

**Note: I have tested with i2c but not with standard MCP23017 or similar**