### PR TITLE
Switch from MCP23x17_GPIO to MCP23x17_INTCAP

### DIFF
--- a/zyncoder.c
+++ b/zyncoder.c
@@ -690,10 +690,10 @@ void zyncoder_mcp23017_ISR(struct wiringPiNodeStruct *wpns, uint16_t base_pin, u
 	#endif
 
 	if (bank == 0) {
-		reg = wiringPiI2CReadReg8(wpns->fd, MCP23x17_GPIOA);
+		reg = wiringPiI2CReadReg8(wpns->fd, MCP23x17_INTCAPA);
 		pin_min = base_pin;
 	} else {
-		reg = wiringPiI2CReadReg8(wpns->fd, MCP23x17_GPIOB);
+		reg = wiringPiI2CReadReg8(wpns->fd, MCP23x17_INTCAPB);
 		pin_min = base_pin + 8;
 	}
 	pin_max = pin_min + 7;


### PR DESCRIPTION
Switching from GPIO read on interrupt to INTCAP will ensure that
the condition(s) that triggered the interrupt are read in the
latched register, rather than the instantanious GPIO register.
This should help with missed/glitched switch bounces.