### PR TITLE
Fix segfault in parse_envar2intarr

### DIFF
--- a/zyncontrol_vx.c
+++ b/zyncontrol_vx.c
@@ -117,10 +117,9 @@ void parse_envar2intarr(const char *envar_name, int *result, int limit) {
 		int i=0;
 		strcpy(envar_cpy, envar_ptr);
 		char *token = strtok_r(envar_cpy, ",", &save_ptr);
-		result[i++] = atoi(token);
 		while (token!=NULL && i<limit) {
-			token = strtok_r(NULL, ",", &save_ptr);
 			result[i++] = atoi(token);
+			token = strtok_r(NULL, ",", &save_ptr);
 		}
 	}
 }


### PR DESCRIPTION
`parse_envar2intarr` segfaults when parsing the environment variable `ZYNTHIAN_WIRING_ENCODER_A=0,0,0,0`.  This happens when we call `atoi` with `NULL` on the 4th iteration of the loop.

Fixed by moving the `atoi` call to immediately after the existing `NULL` check.